### PR TITLE
Add @local_jdk//:jdk dependency when calling _google_java_formatter

### DIFF
--- a/jsinterop_generator.bzl
+++ b/jsinterop_generator.bzl
@@ -107,8 +107,8 @@ def _impl(ctx):
   inputs = [
       ctx.outputs._generated_jar,
       ctx.executable._google_java_formatter,
-      ctx.executable._jar
-  ]
+      ctx.executable._jar,
+  ] + ctx.files._jdk
   ctx.action(
       inputs = inputs,
       outputs = [ctx.outputs._formatted_jar],
@@ -155,6 +155,10 @@ _jsinterop_generator = rule(
             cfg = "host",
             executable = True,
             default = Label("//third_party:jar")
+        ),
+        "_jdk": attr.label(
+            cfg = "host",
+            default = Label("//third_party:jdk")
         ),
         "_google_java_formatter": attr.label(
             cfg = "host",

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -76,6 +76,12 @@ alias(
     visibility = ["//visibility:public"],
 )
 
+alias(
+    name = "jdk",
+    actual = "@local_jdk//:jdk-default",
+    visibility = ["//visibility:public"],
+)
+
 # Tests dependencies
 alias(
     name = "common_externs",


### PR DESCRIPTION
Fixes this issue when using Bazel's sandbox:

Formatting java classes failed: Process exited with status 2 [sandboxed].
Error: could not find libjava.dylib
Error: Could not find Java SE Runtime Environment.