### PR TITLE
Deprecate the generated java api if the js api is deprecated

### DIFF
--- a/java/jsinterop/generator/closure/visitor/MemberCollector.java
+++ b/java/jsinterop/generator/closure/visitor/MemberCollector.java
@@ -37,6 +37,8 @@ import jsinterop.generator.model.AccessModifier;
 import jsinterop.generator.model.Field;
 import jsinterop.generator.model.Method;
 import jsinterop.generator.model.Method.Parameter;
+import jsinterop.generator.model.AnnotationType;
+import jsinterop.generator.model.Annotation;
 
 /** Collect type information. */
 public class MemberCollector extends AbstractClosureVisitor {
@@ -123,13 +125,17 @@ public class MemberCollector extends AbstractClosureVisitor {
 
   @Override
   protected boolean visitField(StaticTypedSlot jsField, boolean isStatic) {
-    getCurrentJavaType()
-        .addField(
-            Field.create(
-                extractName(jsField.getName()),
-                getJavaTypeRegistry().createTypeReference(jsField.getType()),
-                isConstant(jsField),
-                isStatic));
+    Field field = Field.create(
+            extractName(jsField.getName()),
+            getJavaTypeRegistry().createTypeReference(jsField.getType()),
+            isConstant(jsField),
+            isStatic);
+
+    if (jsField.getJSDocInfo() != null && jsField.getJSDocInfo().isDeprecated()) {
+      field.addAnnotation(Annotation.builder().type(AnnotationType.DEPRECATED).build());
+    }
+
+    getCurrentJavaType().addField(field);
     return true;
   }
 
@@ -138,6 +144,9 @@ public class MemberCollector extends AbstractClosureVisitor {
     FunctionType jsMethod = method.toMaybeFunctionType();
 
     Method javaMethod = new Method();
+    if (method.getJSDocInfo() != null && method.getJSDocInfo().isDeprecated()) {
+      javaMethod.addAnnotation(Annotation.builder().type(AnnotationType.DEPRECATED).build());
+    }
     javaMethod.setName(extractName(jsMethod.getDisplayName()));
     javaMethod.setStatic(isStatic);
 

--- a/java/jsinterop/generator/closure/visitor/TypeCollector.java
+++ b/java/jsinterop/generator/closure/visitor/TypeCollector.java
@@ -33,6 +33,7 @@ import com.google.javascript.rhino.jstype.StaticTypedSlot;
 import jsinterop.generator.closure.helper.GenerationContext;
 import jsinterop.generator.helper.ModelHelper;
 import jsinterop.generator.model.Annotation;
+import jsinterop.generator.model.AnnotationType;
 import jsinterop.generator.model.EntityKind;
 import jsinterop.generator.model.Type;
 
@@ -101,6 +102,10 @@ public class TypeCollector extends AbstractClosureVisitor {
     Type javaType =
         createJavaType(type.getDisplayName(), type.isInterface() ? INTERFACE : CLASS, false);
     javaType.setStructural(type.isStructuralInterface());
+
+    if (type.getJSDocInfo() != null && type.getJSDocInfo().isDeprecated()) {
+      javaType.addAnnotation(Annotation.builder().type(AnnotationType.DEPRECATED).build());
+    }
     getJavaTypeRegistry().registerJavaType(javaType, type.getInstanceType());
 
     // keep the current java type to be able to create an extension type later.

--- a/java/jsinterop/generator/helper/ModelHelper.java
+++ b/java/jsinterop/generator/helper/ModelHelper.java
@@ -22,6 +22,7 @@ import static jsinterop.generator.helper.GeneratorUtils.extractName;
 import static jsinterop.generator.helper.GeneratorUtils.extractNamespace;
 import static jsinterop.generator.helper.GeneratorUtils.toCamelUpperCase;
 import static jsinterop.generator.model.Annotation.builder;
+import static jsinterop.generator.model.AnnotationType.DEPRECATED;
 import static jsinterop.generator.model.AnnotationType.JS_FUNCTION;
 import static jsinterop.generator.model.AnnotationType.JS_OVERLAY;
 import static jsinterop.generator.model.AnnotationType.JS_TYPE;
@@ -223,6 +224,10 @@ public class ModelHelper {
 
       jsOverlayMethod.getAnnotations().clear();
       jsOverlayMethod.addAnnotation(Annotation.builder().type(JS_OVERLAY).build());
+
+      if (originalMethod.hasAnnotation(DEPRECATED)) {
+        jsOverlayMethod.addAnnotation(Annotation.builder().type(DEPRECATED).build());
+      }
 
       jsOverlayMethod.setDefault(defaultMethod);
       jsOverlayMethod.setFinal(!defaultMethod);

--- a/java/jsinterop/generator/model/AnnotationType.java
+++ b/java/jsinterop/generator/model/AnnotationType.java
@@ -23,7 +23,8 @@ public enum AnnotationType {
   JS_METHOD(PredefinedTypeReference.JS_METHOD, false, true, true),
   JS_PACKAGE(PredefinedTypeReference.JS_PACKAGE, false, true, false),
   JS_FUNCTION(PredefinedTypeReference.JS_FUNCTION, false, false, false),
-  JS_OVERLAY(PredefinedTypeReference.JS_OVERLAY, false, false, false);
+  JS_OVERLAY(PredefinedTypeReference.JS_OVERLAY, false, false, false),
+  DEPRECATED(PredefinedTypeReference.DEPRECATED, false, false, false);
 
   private final PredefinedTypeReference type;
   private boolean hasNamespaceAttribute;

--- a/java/jsinterop/generator/model/PredefinedTypeReference.java
+++ b/java/jsinterop/generator/model/PredefinedTypeReference.java
@@ -34,6 +34,7 @@ public enum PredefinedTypeReference implements TypeReference {
   OBJECT("Object", "*", "java.lang.Object", "Ljava/lang/Object"),
   STRING("String", "string", "java.lang.String", "Ljava/lang/String"),
   CLASS("Class", null, "java.lang.Class", "Ljava/lang/Class"),
+  DEPRECATED("Deprecated", "deprecated", "java.lang.Deprecated", "Ljava/lang/Deprecated"),
   JS_TYPE("JsType", null, "jsinterop.annotations.JsType", "Ljsinterop/annotations/JsType"),
   JS_PROPERTY(
       "JsProperty", null, "jsinterop.annotations.JsProperty", "Ljsinterop/annotations/JsProperty"),

--- a/java/jsinterop/generator/visitor/FieldsConverter.java
+++ b/java/jsinterop/generator/visitor/FieldsConverter.java
@@ -20,6 +20,7 @@ package jsinterop.generator.visitor;
 import static com.google.common.base.Predicates.not;
 import static jsinterop.generator.helper.GeneratorUtils.toCamelUpperCase;
 import static jsinterop.generator.model.AccessModifier.DEFAULT;
+import static jsinterop.generator.model.AnnotationType.DEPRECATED;
 import static jsinterop.generator.model.AnnotationType.JS_OVERLAY;
 import static jsinterop.generator.model.AnnotationType.JS_PROPERTY;
 import static jsinterop.generator.model.AnnotationType.JS_TYPE;
@@ -190,6 +191,10 @@ public class FieldsConverter extends AbstractModelVisitor {
     Annotation.Builder jsPropertyAnnotation = Annotation.builder().type(JS_PROPERTY);
     if (!useBeanConvention || !fieldNameIsLowerCamelCase) {
       jsPropertyAnnotation.nameAttribute(fieldName);
+    }
+
+    if (field.getAnnotation(DEPRECATED) != null) {
+      accessor.addAnnotation(Annotation.builder().type(DEPRECATED).build());
     }
     accessor.addAnnotation(jsPropertyAnnotation.build());
 

--- a/javatests/jsinterop/generator/externs/simpleclass/BUILD
+++ b/javatests/jsinterop/generator/externs/simpleclass/BUILD
@@ -35,6 +35,7 @@ jsinterop_generator_test(
         "SimpleInterface.java",
         "SimpleInterface__Constants.java",
         "SimpleStructuralInterface.java",
+        "DeprecatedInterface.java",
     ],
     deps = [":native_types"],
 )

--- a/javatests/jsinterop/generator/externs/simpleclass/DeprecatedInterface.java
+++ b/javatests/jsinterop/generator/externs/simpleclass/DeprecatedInterface.java
@@ -1,0 +1,14 @@
+package jsinterop.generator.externs.simpleclass;
+
+import java.lang.Deprecated;
+import java.lang.String;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL)
+@Deprecated
+public interface DeprecatedInterface {
+  boolean deprecatedMethod(String bar, String foo, boolean baz);
+
+  boolean deprecatedMethod(String bar, String foo);
+}

--- a/javatests/jsinterop/generator/externs/simpleclass/SimpleClass.java
+++ b/javatests/jsinterop/generator/externs/simpleclass/SimpleClass.java
@@ -1,5 +1,9 @@
 package jsinterop.generator.externs.simpleclass;
 
+import java.lang.Deprecated;
+import java.lang.Double;
+import java.lang.Object;
+import java.lang.String;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
@@ -8,6 +12,38 @@ import jsinterop.base.Js;
 
 @JsType(isNative = true, namespace = JsPackage.GLOBAL)
 public class SimpleClass {
+  @JsType(isNative = true, name = "?", namespace = JsPackage.GLOBAL)
+  public interface DeprecatedMethodFooUnionType {
+    @JsOverlay
+    static SimpleClass.DeprecatedMethodFooUnionType of(Object o) {
+      return Js.cast(o);
+    }
+
+    @JsOverlay
+    default double asDouble() {
+      return Js.asDouble(this);
+    }
+
+    @JsOverlay
+    default String asString() {
+      return Js.asString(this);
+    }
+
+    @JsOverlay
+    default boolean isDouble() {
+      return (Object) this instanceof Double;
+    }
+
+    @JsOverlay
+    default boolean isString() {
+      return (Object) this instanceof String;
+    }
+  }
+
+  @Deprecated
+  @JsOverlay
+  public static final String deprecatedConstant = SimpleClass__Constants.deprecatedConstant;
+  @Deprecated public static String deprecatedStaticProperty;
   public static double staticProperty;
 
   @JsOverlay
@@ -41,6 +77,8 @@ public class SimpleClass {
   @JsMethod(name = "wait")
   public static native void wait__STATIC();
 
+  @Deprecated
+  public String deprecatedProperty;
   public String fooProperty;
   public String[][][] fooProperty2;
   public boolean readonlyProperty;
@@ -50,8 +88,59 @@ public class SimpleClass {
 
   public SimpleClass(String foo) {}
 
+
   @JsMethod(name = "clone")
   public native Object clone_();
+
+  @Deprecated
+  public native boolean deprecatedMethod(String bar, SimpleClass.DeprecatedMethodFooUnionType foo, JsObject baz);
+
+  @JsOverlay
+  @Deprecated
+  public final boolean deprecatedMethod(String bar, SimpleClass.DeprecatedMethodFooUnionType foo, Object baz) {
+    return deprecatedMethod(bar, foo, Js.<JsObject>uncheckedCast(baz));
+  }
+
+  @Deprecated
+  public native boolean deprecatedMethod(String bar, SimpleClass.DeprecatedMethodFooUnionType foo);
+
+  @JsOverlay
+  @Deprecated
+  public final boolean deprecatedMethod(String bar, String foo, JsObject baz) {
+    return deprecatedMethod(
+            bar, Js.<SimpleClass.DeprecatedMethodFooUnionType>uncheckedCast(foo), baz);
+  }
+
+  @JsOverlay
+  @Deprecated
+  public final boolean deprecatedMethod(String bar, String foo, Object baz) {
+    return deprecatedMethod(bar, foo, Js.<JsObject>uncheckedCast(baz));
+  }
+
+  @JsOverlay
+  @Deprecated
+  public final boolean deprecatedMethod(String bar, String foo) {
+    return deprecatedMethod(bar, Js.<SimpleClass.DeprecatedMethodFooUnionType>uncheckedCast(foo));
+  }
+
+  @JsOverlay
+  @Deprecated
+  public final boolean deprecatedMethod(String bar, double foo, JsObject baz) {
+    return deprecatedMethod(
+            bar, Js.<SimpleClass.DeprecatedMethodFooUnionType>uncheckedCast(foo), baz);
+  }
+
+  @JsOverlay
+  @Deprecated
+  public final boolean deprecatedMethod(String bar, double foo, Object baz) {
+    return deprecatedMethod(bar, foo, Js.<JsObject>uncheckedCast(baz));
+  }
+
+  @JsOverlay
+  @Deprecated
+  public final boolean deprecatedMethod(String bar, double foo) {
+    return deprecatedMethod(bar, Js.<SimpleClass.DeprecatedMethodFooUnionType>uncheckedCast(foo));
+  }
 
   @JsMethod(name = "equals")
   public native boolean equals_(Object other);

--- a/javatests/jsinterop/generator/externs/simpleclass/SimpleClass__Constants.java
+++ b/javatests/jsinterop/generator/externs/simpleclass/SimpleClass__Constants.java
@@ -1,10 +1,12 @@
 package jsinterop.generator.externs.simpleclass;
 
+import java.lang.Deprecated;
 import java.lang.String;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
 
 @JsType(isNative = true, name = "SimpleClass", namespace = JsPackage.GLOBAL)
 class SimpleClass__Constants {
+  @Deprecated static String deprecatedConstant;
   static String staticReadonlyProperty;
 }

--- a/javatests/jsinterop/generator/externs/simpleclass/SimpleInterface.java
+++ b/javatests/jsinterop/generator/externs/simpleclass/SimpleInterface.java
@@ -1,5 +1,6 @@
 package jsinterop.generator.externs.simpleclass;
 
+import java.lang.Deprecated;
 import java.lang.String;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
@@ -8,16 +9,32 @@ import jsinterop.annotations.JsType;
 
 @JsType(isNative = true, namespace = JsPackage.GLOBAL)
 public interface SimpleInterface {
+  @Deprecated @JsOverlay boolean deprecatedStaticProperty = SimpleInterface__Constants.deprecatedStaticProperty;
   @JsOverlay String staticProperty = SimpleInterface__Constants.staticProperty;
+
+  @Deprecated
+  boolean deprecatedMethod(String bar, String foo, boolean baz);
+
+  @Deprecated
+  boolean deprecatedMethod(String bar, String foo);
+
   boolean fooMethod(String foo, String bar, boolean baz);
 
   boolean fooMethod(String foo, String bar);
+
+  @Deprecated
+  @JsProperty
+  String getDeprecatedProperty();
 
   @JsProperty
   String getFooProperty();
 
   @JsProperty
   boolean isReadonlyProperty();
+
+  @Deprecated
+  @JsProperty
+  void setDeprecatedProperty(String deprecatedProperty);
 
   @JsProperty
   void setFooProperty(String fooProperty);

--- a/javatests/jsinterop/generator/externs/simpleclass/SimpleInterface__Constants.java
+++ b/javatests/jsinterop/generator/externs/simpleclass/SimpleInterface__Constants.java
@@ -1,10 +1,12 @@
 package jsinterop.generator.externs.simpleclass;
 
+import java.lang.Deprecated;
 import java.lang.String;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
 
 @JsType(isNative = true, name = "SimpleInterface", namespace = JsPackage.GLOBAL)
 class SimpleInterface__Constants {
+  @Deprecated static boolean deprecatedStaticProperty;
   static String staticProperty;
 }

--- a/javatests/jsinterop/generator/externs/simpleclass/simpleclass.js
+++ b/javatests/jsinterop/generator/externs/simpleclass/simpleclass.js
@@ -67,12 +67,31 @@ SimpleClass.wait = function() {};
 /**
  * @const {string}
  */
-SimpleClass.staticReadonlyProperty
+SimpleClass.staticReadonlyProperty;
+
+/**
+ * @deprecated
+ * @const {string}
+ */
+SimpleClass.deprecatedConstant;
+
+/**
+ * @deprecated
+ * @type {string}
+ */
+SimpleClass.deprecatedStaticProperty;
+
 
 /**
  * @type {string}
  */
 SimpleClass.prototype.fooProperty;
+
+/**
+ * @deprecated
+ * @type {string}
+ */
+SimpleClass.prototype.deprecatedProperty;
 
 /**
  * @const {boolean}
@@ -96,6 +115,15 @@ SimpleClass.prototype.thisType;
  * @return {boolean}
  */
 SimpleClass.prototype.fooMethod = function(foo, bar, opt_baz) {};
+
+/**
+ * @deprecated
+ * @param {string} bar
+ * @param {string|number} foo
+ * @param {Object=} opt_baz
+ * @return {boolean}
+ */
+SimpleClass.prototype.deprecatedMethod = function(bar, foo, opt_baz) {};
 
 // Instance methods conflicting with java.lang.Object methods need to be
 // renamed.
@@ -151,6 +179,12 @@ function SimpleInterface() {}
 SimpleInterface.staticProperty;
 
 /**
+ * @deprecated
+ * @const {boolean}
+ */
+SimpleInterface.deprecatedStaticProperty;
+
+/**
  * @type {string}
  */
 SimpleInterface.prototype.fooProperty;
@@ -161,12 +195,27 @@ SimpleInterface.prototype.fooProperty;
 SimpleInterface.prototype.readonlyProperty;
 
 /**
+ * @deprecated
+ * @type {string}
+ */
+SimpleInterface.prototype.deprecatedProperty;
+
+/**
  * @param {string} foo
  * @param {string} bar
  * @param {boolean=} opt_baz
  * @return {boolean}
  */
 SimpleInterface.prototype.fooMethod = function(foo, bar, opt_baz) {};
+
+/**
+ * @deprecated
+ * @param {string} bar
+ * @param {string} foo
+ * @param {boolean=} opt_baz
+ * @return {boolean}
+ */
+SimpleInterface.prototype.deprecatedMethod = function(bar, foo, opt_baz) {};
 
 
 /**
@@ -181,6 +230,19 @@ function SimpleStructuralInterface() {}
  * @return {boolean}
  */
 SimpleStructuralInterface.prototype.fooMethod = function(foo, bar, opt_baz) {};
+
+/**@deprecated
+ * @record
+ */
+function DeprecatedInterface() {}
+
+/**
+ * @param {string} bar
+ * @param {string} foo
+ * @param {boolean=} opt_baz
+ * @return {boolean}
+ */
+DeprecatedInterface.prototype.deprecatedMethod = function(bar, foo, opt_baz) {};
 
 // TODO(b/34389745): Type alias with a constant is not supported.
 /**


### PR DESCRIPTION
This change will add `@Deprecated`  on the generated java method or field when the corresponding method or field in the closure extern is deprecated, this will reduce the possibility of errors that happens due to old api usage.