### PR TITLE
Travis ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,40 @@
+# trusty beta image has jdk8, gcc4.8.4
+dist: trusty
+sudo: required
+# xcode8 has jdk8
+osx_image: xcode8
+# Not technically required but suppresses 'Ruby' in Job status message.
+language: java
+
+os:
+  - linux
+  - osx
+
+env:
+  - BAZEL=0.23.0
+
+before_install:
+  - |
+    if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
+      OS=darwin
+    else
+      sysctl kernel.unprivileged_userns_clone=1
+      OS=linux
+    fi
+    wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/${BAZEL}/bazel-${BAZEL}-installer-${OS}-x86_64.sh"
+    chmod +x install.sh
+    ./install.sh --user
+    rm -f install.sh
+
+before_script:
+  - echo "startup --output_base=$HOME/.cache/bazel" >> .bazelrc
+  # Avoid progress indicators that can blow out log which makes using WEB UI difficult
+  - echo "common --noshow_progress" >> .bazelrc
+  - echo "common --noshow_loading_progress" >> .bazelrc
+  # This is so we understand failures better
+  - echo "build --verbose_failures" >> .bazelrc
+
+script: ./bazel_build_test.sh
+
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-JsInterop Generator
-===================
+# JsInterop Generator &middot; [![Build Status](https://secure.travis-ci.org/google/jsinterop-generator.png?branch=master)](http://travis-ci.org/google/jsinterop-generator)
 
 The jsinterop generator is a java program that takes closure extern files as input and generates
 Java classes annotated with [JsInterop annotations](https://goo.gl/agme3T).


### PR DESCRIPTION
This adds basic TravisCI integration. Notifications on build failures/recovery have been disabled but other options are possible as discussed in google/elemental2#82