### PR TITLE
Support instance member overriding a static member with union types

### DIFF
--- a/java/jsinterop/generator/visitor/MembersClassCleaner.java
+++ b/java/jsinterop/generator/visitor/MembersClassCleaner.java
@@ -17,8 +17,7 @@
 
 package jsinterop.generator.visitor;
 
-import static jsinterop.generator.model.AnnotationType.JS_METHOD;
-import static jsinterop.generator.model.AnnotationType.JS_PROPERTY;
+import static jsinterop.generator.model.AnnotationType.*;
 import static jsinterop.generator.model.EntityKind.METHOD;
 
 import java.util.ArrayList;
@@ -163,12 +162,14 @@ public class MembersClassCleaner implements ModelVisitor {
                 String name = entity.getName();
                 entity.setName(name + "_STATIC");
 
-                // TODO(dramaix): add a javadoc above the field explaining why it was renamed
-                AnnotationType annotationType =
-                    entity.getKind() == METHOD ? JS_METHOD : JS_PROPERTY;
+                if (!entity.hasAnnotation(JS_OVERLAY)) {
+                  // TODO(dramaix): add a javadoc above the field explaining why it was renamed
+                  AnnotationType annotationType =
+                          entity.getKind() == METHOD ? JS_METHOD : JS_PROPERTY;
 
-                ModelHelper.addAnnotationNameAttributeIfNotEmpty(
-                    entity, name, annotationType, true);
+                  ModelHelper.addAnnotationNameAttributeIfNotEmpty(
+                          entity, name, annotationType, true);
+                }
               }
             }
           }

--- a/java/jsinterop/generator/visitor/MembersClassCleaner.java
+++ b/java/jsinterop/generator/visitor/MembersClassCleaner.java
@@ -17,7 +17,9 @@
 
 package jsinterop.generator.visitor;
 
-import static jsinterop.generator.model.AnnotationType.*;
+import static jsinterop.generator.model.AnnotationType.JS_METHOD;
+import static jsinterop.generator.model.AnnotationType.JS_OVERLAY;
+import static jsinterop.generator.model.AnnotationType.JS_PROPERTY;
 import static jsinterop.generator.model.EntityKind.METHOD;
 
 import java.util.ArrayList;

--- a/java/jsinterop/generator/visitor/UnionTypeHelperTypeCreator.java
+++ b/java/jsinterop/generator/visitor/UnionTypeHelperTypeCreator.java
@@ -80,12 +80,18 @@ public class UnionTypeHelperTypeCreator implements ModelVisitor {
 
           @Override
           public boolean shouldProcessField(Field field) {
+            if (field.isStatic()) {
+              currentNameStack.push("Static");
+            }
             currentNameStack.push(toCamelUpperCase(field.getName()));
             return true;
           }
 
           @Override
           public Field rewriteField(Field field) {
+            if (field.isStatic()) {
+              currentNameStack.pop();
+            }
             currentNameStack.pop();
             return field;
           }
@@ -95,6 +101,9 @@ public class UnionTypeHelperTypeCreator implements ModelVisitor {
             // JsFunction type only have one method named onInvoke, don't use the method name
             // because it doesn't give us any much more information.
             if (!isCurrentTypeJsFunction()) {
+              if (method.isStatic()) {
+                currentNameStack.push("Static");
+              }
               currentNameStack.push(
                   method.getKind() == CONSTRUCTOR
                       ? "Constructor"
@@ -106,6 +115,9 @@ public class UnionTypeHelperTypeCreator implements ModelVisitor {
           @Override
           public Method rewriteMethod(Method method) {
             if (!isCurrentTypeJsFunction()) {
+              if (method.isStatic()) {
+                currentNameStack.pop();
+              }
               currentNameStack.pop();
             }
 

--- a/javatests/jsinterop/generator/externs/overloads/BUILD
+++ b/javatests/jsinterop/generator/externs/overloads/BUILD
@@ -1,0 +1,22 @@
+# Description:
+#   Tests conversion of "overloaded" members, static and non-static
+#
+
+load(
+    "//javatests/jsinterop/generator:jsinterop_generator_test.bzl",
+    "jsinterop_generator_test",
+)
+
+package(
+    default_visibility = ["//:__subpackages__"],
+    # Apache2
+    licenses = ["notice"],
+)
+
+jsinterop_generator_test(
+    name = "overloads",
+    srcs = ["overloads.js"],
+    expected_output = [
+        "Foo.java.txt",
+    ],
+)

--- a/javatests/jsinterop/generator/externs/overloads/Foo.java.txt
+++ b/javatests/jsinterop/generator/externs/overloads/Foo.java.txt
@@ -1,5 +1,6 @@
 package jsinterop.generator.externs.overloads;
 
+import jsinterop.annotations.JsFunction;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
@@ -9,6 +10,16 @@ import jsinterop.base.Js;
 
 @JsType(isNative = true, namespace = JsPackage.GLOBAL)
 public class Foo {
+  @JsFunction
+  public interface FunctionPropertyFn {
+    void onInvoke();
+  }
+
+  @JsFunction
+  public interface FunctionPropertyFn0 {
+    void onInvoke();
+  }
+
   @JsType(isNative = true, name = "?", namespace = JsPackage.GLOBAL)
   public interface StaticUnionArgMethodArgUnionType {
     @JsOverlay
@@ -121,6 +132,9 @@ public class Foo {
     }
   }
 
+  @JsProperty(name = "functionProperty")
+  public static Foo.FunctionPropertyFn functionProperty_STATIC;
+
   @JsProperty(name = "unionProperty")
   public static Foo.StaticUnionPropertyUnionType unionProperty_STATIC;
 
@@ -139,6 +153,7 @@ public class Foo {
     return unionArgMethod(Js.<Foo.StaticUnionArgMethodArgUnionType>uncheckedCast(arg));
   }
 
+  public Foo.FunctionPropertyFn0 functionProperty;
   public Foo.UnionPropertyUnionType unionProperty;
 
   public native Object noArgMethod();

--- a/javatests/jsinterop/generator/externs/overloads/Foo.java.txt
+++ b/javatests/jsinterop/generator/externs/overloads/Foo.java.txt
@@ -1,0 +1,157 @@
+package jsinterop.generator.externs.overloads;
+
+import jsinterop.annotations.JsMethod;
+import jsinterop.annotations.JsOverlay;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsProperty;
+import jsinterop.annotations.JsType;
+import jsinterop.base.Js;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL)
+public class Foo {
+  @JsType(isNative = true, name = "?", namespace = JsPackage.GLOBAL)
+  public interface StaticUnionArgMethodArgUnionType {
+    @JsOverlay
+    static Foo.StaticUnionArgMethodArgUnionType of(Object o) {
+      return Js.cast(o);
+    }
+
+    @JsOverlay
+    default double asDouble() {
+      return Js.asDouble(this);
+    }
+
+    @JsOverlay
+    default String asString() {
+      return Js.asString(this);
+    }
+
+    @JsOverlay
+    default boolean isDouble() {
+      return (Object) this instanceof Double;
+    }
+
+    @JsOverlay
+    default boolean isString() {
+      return (Object) this instanceof String;
+    }
+  }
+
+  @JsType(isNative = true, name = "?", namespace = JsPackage.GLOBAL)
+  public interface StaticUnionPropertyUnionType {
+    @JsOverlay
+    static Foo.StaticUnionPropertyUnionType of(Object o) {
+      return Js.cast(o);
+    }
+
+    @JsOverlay
+    default double asDouble() {
+      return Js.asDouble(this);
+    }
+
+    @JsOverlay
+    default String asString() {
+      return Js.asString(this);
+    }
+
+    @JsOverlay
+    default boolean isDouble() {
+      return (Object) this instanceof Double;
+    }
+
+    @JsOverlay
+    default boolean isString() {
+      return (Object) this instanceof String;
+    }
+  }
+
+  @JsType(isNative = true, name = "?", namespace = JsPackage.GLOBAL)
+  public interface UnionArgMethodArgUnionType {
+    @JsOverlay
+    static Foo.UnionArgMethodArgUnionType of(Object o) {
+      return Js.cast(o);
+    }
+
+    @JsOverlay
+    default double asDouble() {
+      return Js.asDouble(this);
+    }
+
+    @JsOverlay
+    default String asString() {
+      return Js.asString(this);
+    }
+
+    @JsOverlay
+    default boolean isDouble() {
+      return (Object) this instanceof Double;
+    }
+
+    @JsOverlay
+    default boolean isString() {
+      return (Object) this instanceof String;
+    }
+  }
+
+  @JsType(isNative = true, name = "?", namespace = JsPackage.GLOBAL)
+  public interface UnionPropertyUnionType {
+    @JsOverlay
+    static Foo.UnionPropertyUnionType of(Object o) {
+      return Js.cast(o);
+    }
+
+    @JsOverlay
+    default double asDouble() {
+      return Js.asDouble(this);
+    }
+
+    @JsOverlay
+    default String asString() {
+      return Js.asString(this);
+    }
+
+    @JsOverlay
+    default boolean isDouble() {
+      return (Object) this instanceof Double;
+    }
+
+    @JsOverlay
+    default boolean isString() {
+      return (Object) this instanceof String;
+    }
+  }
+
+  @JsProperty(name = "unionProperty")
+  public static Foo.StaticUnionPropertyUnionType unionProperty_STATIC;
+
+  @JsMethod(name = "noArgMethod")
+  public static native Object noArgMethod_STATIC();
+
+  public static native Object unionArgMethod(Foo.StaticUnionArgMethodArgUnionType arg);
+
+  @JsOverlay
+  public static final Object unionArgMethod_STATIC(String arg) {
+    return unionArgMethod(Js.<Foo.StaticUnionArgMethodArgUnionType>uncheckedCast(arg));
+  }
+
+  @JsOverlay
+  public static final Object unionArgMethod_STATIC(double arg) {
+    return unionArgMethod(Js.<Foo.StaticUnionArgMethodArgUnionType>uncheckedCast(arg));
+  }
+
+  public Foo.UnionPropertyUnionType unionProperty;
+
+  public native Object noArgMethod();
+
+  @JsOverlay
+  public final Object unionArgMethod(String arg) {
+    return unionArgMethod(Js.<Foo.UnionArgMethodArgUnionType>uncheckedCast(arg));
+  }
+
+  public native Object unionArgMethod(Foo.UnionArgMethodArgUnionType arg);
+
+  @JsOverlay
+  public final Object unionArgMethod(double arg) {
+    return unionArgMethod(Js.<Foo.UnionArgMethodArgUnionType>uncheckedCast(arg));
+  }
+}

--- a/javatests/jsinterop/generator/externs/overloads/overloads.js
+++ b/javatests/jsinterop/generator/externs/overloads/overloads.js
@@ -29,3 +29,13 @@ Foo.unionProperty;
  * @type {string|number}
  */
 Foo.prototype.unionProperty;
+
+/**
+ * @type {function():void}
+ */
+Foo.functionProperty;
+
+/**
+ * @type {function():void}
+ */
+Foo.prototype.functionProperty;

--- a/javatests/jsinterop/generator/externs/overloads/overloads.js
+++ b/javatests/jsinterop/generator/externs/overloads/overloads.js
@@ -1,0 +1,31 @@
+
+/**
+ * @fileoverview Test "overloaded" method conventions
+ * @externs
+ */
+
+/**
+ * @constructor
+ */
+function Foo() {}
+
+Foo.noArgMethod = function() {};
+Foo.prototype.noArgMethod = function() {};
+
+/**
+ * @param {string|number} arg
+ */
+Foo.unionArgMethod = function(arg) {};
+/**
+ * @param {string|number} arg
+ */
+Foo.prototype.unionArgMethod = function(arg) {};
+
+/**
+ * @type {string|number}
+ */
+Foo.unionProperty;
+/**
+ * @type {string|number}
+ */
+Foo.prototype.unionProperty;


### PR DESCRIPTION
Proposed fix to disambiguate the generated union type for a static and instance member with the same name (and for a method, with the same param name). A nicer fix might be where the enclosing type only takes a single union type for the given method name plus arg name plus types, so that it could be reused, but this is not a general fix.

It could also perhaps be possible to reorder `MembersClassCleaner` and `UnionTypeHelperTypeCreator` in `VisitorHelper` (so that `_STATIC` is already appended and could be used when generating the union type), but there seem to be other dependencies on the order as it is.

Fixes #46

Does not address #47.